### PR TITLE
fix: restore scraper after CIS WorkBench Vue.js SPA migration (closes #9)

### DIFF
--- a/src/cis_bench/fetcher/strategies/__init__.py
+++ b/src/cis_bench/fetcher/strategies/__init__.py
@@ -6,12 +6,16 @@ Strategies are auto-registered when imported.
 from .base import ScraperStrategy
 from .detector import StrategyDetector
 from .v1_current import WorkbenchV1Strategy
+from .v2_2026 import WorkbenchV2Strategy
 
-# Auto-register current strategy
-StrategyDetector.register_strategy(WorkbenchV1Strategy())
+# Register newest strategy first so the detector prefers it while keeping
+# V1 available as a fallback for older cached HTML.
+StrategyDetector.register_strategy(WorkbenchV1Strategy(), position=0)
+StrategyDetector.register_strategy(WorkbenchV2Strategy(), position=0)
 
 __all__ = [
     "ScraperStrategy",
     "StrategyDetector",
     "WorkbenchV1Strategy",
+    "WorkbenchV2Strategy",
 ]

--- a/src/cis_bench/fetcher/strategies/v2_2026.py
+++ b/src/cis_bench/fetcher/strategies/v2_2026.py
@@ -1,0 +1,228 @@
+"""CIS WorkBench scraper strategy for Vue.js SPA HTML (2026+).
+
+CIS WorkBench migrated recommendation pages to a Vue.js SPA in early 2026.
+Content previously found in server-rendered ``<div id="...-recommendation-data">``
+blocks now lives in attributes on Vue web components:
+
+- ``<wb-recommendation-data attribute="description" text="...">`` — text fields
+- ``<wb-recommendation-feature-controls :controls="JSON.parse('...')">`` — CIS Controls
+- ``<wb-recommendation-mitre-mappings :mappings="JSON.parse('...')">`` — MITRE mapping
+- ``<wb-recommendation-artifacts artifacts-json="[...]">`` — legacy attr still served
+
+Two quirks of the new format are handled here:
+
+1. Vue serializes attribute payloads as JavaScript-escaped strings
+   (``\\u0022`` for ``"``). The browser's ``JSON.parse`` decodes those
+   escapes first; Python's :func:`json.loads` does not decode them outside
+   of JSON string contexts, so we decode them ourselves before parsing.
+2. The ``:controls`` payload is sometimes serialized as a dict keyed by
+   index (``{"0": {...}, "1": {...}}``) instead of a list, and ``ig1/ig2/ig3``
+   can be ``null``. Both are normalized so the Pydantic model validates.
+"""
+
+import json
+import re
+from typing import Any
+
+from bs4 import BeautifulSoup
+
+from cis_bench.models.benchmark import CISControl, MITREMapping
+from cis_bench.utils.parsers import WorkbenchParser
+
+from .base import ScraperStrategy
+
+_UNICODE_ESCAPE_RE = re.compile(r"\\u([0-9a-fA-F]{4})")
+_JSON_PARSE_RE = re.compile(r"^JSON\.parse\('(.+)'\)$", re.DOTALL)
+
+
+def _decode_vue_payload(raw: str | None) -> str | None:
+    """Unwrap ``JSON.parse('...')`` and decode ``\\uXXXX`` escapes.
+
+    Args:
+        raw: The raw attribute value captured from a Vue web component.
+
+    Returns:
+        A JSON string suitable for :func:`json.loads`, or ``None`` when
+        the input is empty.
+    """
+    if not raw:
+        return None
+    stripped = raw.strip()
+    match = _JSON_PARSE_RE.search(stripped)
+    payload = match.group(1) if match else stripped
+    return _UNICODE_ESCAPE_RE.sub(lambda h: chr(int(h.group(1), 16)), payload)
+
+
+class WorkbenchV2Strategy(ScraperStrategy):
+    """Scraper for Vue.js SPA CIS WorkBench HTML (2026+)."""
+
+    # Pydantic field name → wb-recommendation-data ``attribute=`` value.
+    _DATA_ATTRIBUTES = {
+        "description": "description",
+        "rationale": "rationale_statement",
+        "impact": "impact_statement",
+        "audit": "audit_procedure",
+        "remediation": "remediation_procedure",
+        "default_value": "default_value",
+        "artifact_equation": "artifact_equation",
+        "references": "references",
+        "additional_info": "notes",
+    }
+
+    @property
+    def version(self) -> str:
+        return "v2_2026_01"
+
+    @property
+    def selectors(self) -> dict[str, dict[str, str]]:
+        return {
+            field: {"tag": "wb-recommendation-data", "attribute": attr}
+            for field, attr in self._DATA_ATTRIBUTES.items()
+        }
+
+    def is_compatible(self, html: str) -> bool:
+        """Detect the Vue SPA signature.
+
+        A page is considered compatible if it contains at least one
+        ``wb-recommendation-data`` element for one of the core content
+        attributes. Checking multiple attributes makes detection tolerant
+        of minor upstream variations.
+        """
+        soup = BeautifulSoup(html, "html.parser")
+        for signature_attr in ("description", "audit_procedure", "rationale_statement"):
+            if soup.find("wb-recommendation-data", attrs={"attribute": signature_attr}):
+                return True
+        return False
+
+    def extract_recommendation(self, html: str) -> dict[str, Any]:
+        """Extract every field the Pydantic ``Recommendation`` model needs."""
+        soup = BeautifulSoup(html, "html.parser")
+        data: dict[str, Any] = {}
+
+        for field, attr_value in self._DATA_ATTRIBUTES.items():
+            el = soup.find("wb-recommendation-data", attrs={"attribute": attr_value})
+            data[field] = self._clean_text(el.get("text") if el else None)
+
+        status_el = soup.find("wb-recommendation-data", attrs={"attribute": "automated_scoring"})
+        status_text = self._clean_text(status_el.get("text") if status_el else None) or ""
+        data["assessment_status"] = self._normalize_status(status_text)
+
+        profiles_el = soup.find("wb-recommendation-data", attrs={"attribute": "profiles"})
+        profiles_text = self._clean_text(profiles_el.get("text") if profiles_el else None)
+        data["profiles"] = [profiles_text] if profiles_text else []
+
+        data["cis_controls"] = self._extract_cis_controls(soup)
+        data["mitre_mapping"] = self._extract_mitre(soup)
+        data["nist_controls"] = WorkbenchParser.parse_nist_controls(data.get("references"))
+        data["artifacts"] = self._extract_artifacts(soup)
+        data["parent"] = WorkbenchParser.parse_parent_link(html)
+
+        return data
+
+    @staticmethod
+    def _clean_text(value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    @staticmethod
+    def _normalize_status(text: str) -> str:
+        lowered = text.lower()
+        if "automated" in lowered:
+            return "Automated"
+        if "manual" in lowered:
+            return "Manual"
+        return text if text else "Unknown"
+
+    @staticmethod
+    def _parse_vue_json(raw: str | None) -> Any | None:
+        decoded = _decode_vue_payload(raw)
+        if decoded is None:
+            return None
+        try:
+            return json.loads(decoded)
+        except json.JSONDecodeError:
+            return None
+
+    def _extract_cis_controls(self, soup: BeautifulSoup) -> list[CISControl]:
+        el = soup.find("wb-recommendation-feature-controls")
+        if not el:
+            return []
+
+        # Prefer the Vue ``:controls`` attribute; fall back to the pre-2026
+        # ``json-controls`` attr so cached HTML still parses.
+        parsed = self._parse_vue_json(el.get(":controls") or el.get("controls"))
+        if parsed is None:
+            legacy = el.get("json-controls")
+            if legacy:
+                try:
+                    parsed = json.loads(legacy)
+                except json.JSONDecodeError:
+                    parsed = None
+
+        if isinstance(parsed, dict):
+            items: list[Any] = list(parsed.values())
+        elif isinstance(parsed, list):
+            items = parsed
+        else:
+            return []
+
+        controls: list[CISControl] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            try:
+                controls.append(
+                    CISControl(
+                        version=item["version"],
+                        control=item["control"],
+                        title=item.get("title", ""),
+                        # ig1/ig2/ig3 may be null in WorkBench data; Pydantic requires bool.
+                        ig1=bool(item.get("ig1")),
+                        ig2=bool(item.get("ig2")),
+                        ig3=bool(item.get("ig3")),
+                    )
+                )
+            except (KeyError, TypeError, ValueError):
+                continue
+        return controls
+
+    def _extract_mitre(self, soup: BeautifulSoup) -> MITREMapping | None:
+        el = soup.find("wb-recommendation-mitre-mappings")
+        if not el:
+            return None
+        parsed = self._parse_vue_json(el.get(":mappings") or el.get("mappings"))
+        if not isinstance(parsed, dict):
+            return None
+
+        # WorkBench uses singular/capitalized keys (``Technique``, ``Tactics``,
+        # ``Mitigations``); accept lowercase plural variants too for resilience.
+        techniques = parsed.get("Technique") or parsed.get("techniques") or []
+        tactics = parsed.get("Tactics") or parsed.get("tactics") or []
+        mitigations = parsed.get("Mitigations") or parsed.get("mitigations") or []
+
+        if not (techniques or tactics or mitigations):
+            return None
+        return MITREMapping(
+            techniques=list(techniques),
+            tactics=list(tactics),
+            mitigations=list(mitigations),
+        )
+
+    def _extract_artifacts(self, soup: BeautifulSoup) -> list:
+        el = soup.find("wb-recommendation-artifacts")
+        if not el:
+            return []
+
+        # The legacy ``artifacts-json`` attribute is still served alongside
+        # the Vue ``:artifacts`` attribute; prefer it when present.
+        legacy = el.get("artifacts-json")
+        if legacy:
+            return WorkbenchParser.parse_artifacts_json(legacy)
+
+        decoded = _decode_vue_payload(el.get(":artifacts"))
+        if decoded:
+            return WorkbenchParser.parse_artifacts_json(decoded)
+
+        return []

--- a/tests/integration/test_strategies_v2.py
+++ b/tests/integration/test_strategies_v2.py
@@ -1,0 +1,323 @@
+"""Tests for WorkbenchV2Strategy (Vue.js SPA era, 2026+).
+
+Covers the four failure modes that broke the scraper after the
+CIS WorkBench Vue migration:
+
+1. ``is_compatible`` must match the new ``wb-recommendation-data`` format.
+2. ``\\uXXXX`` escapes in ``JSON.parse('...')`` payloads must be decoded.
+3. ``:controls`` JSON can be either a list or a dict keyed by index, and
+   ``ig1/ig2/ig3`` may be ``null``.
+4. MITRE mappings now live on ``wb-recommendation-mitre-mappings`` with
+   capitalized singular/plural keys (``Technique``/``Tactics``/``Mitigations``).
+"""
+
+import pytest
+
+from cis_bench.fetcher.strategies.detector import StrategyDetector
+from cis_bench.fetcher.strategies.v1_current import WorkbenchV1Strategy
+from cis_bench.fetcher.strategies.v2_2026 import WorkbenchV2Strategy, _decode_vue_payload
+from cis_bench.models.benchmark import CISControl, MITREMapping, Recommendation
+
+
+def _js_escape(s: str) -> str:
+    """Encode a string the way Vue does when serializing to an attribute value."""
+    return "".join(f"\\u{ord(c):04x}" if c in ('"', "\\", "'") else c for c in s)
+
+
+def _vue_json_attr(value: object) -> str:
+    """Build a ``JSON.parse('...')`` wrapper with ``\\uXXXX``-escaped quotes."""
+    import json as _json
+
+    return f"JSON.parse('{_js_escape(_json.dumps(value))}')"
+
+
+@pytest.fixture
+def v2_full_html():
+    """Complete V2 HTML with every field the scraper reads populated."""
+    controls_payload = _vue_json_attr(
+        {
+            "0": {
+                "title": "Collect Detailed Audit Logs",
+                "control": "8.5",
+                "version": 8,
+                "ig1": False,
+                "ig2": True,
+                "ig3": True,
+            },
+            "1": {
+                "title": "Establish Access Controls",
+                "control": "6.8",
+                "version": 8,
+                # ig1 intentionally null — must be coerced to False.
+                "ig1": None,
+                "ig2": True,
+                "ig3": True,
+            },
+        }
+    )
+    mitre_payload = _vue_json_attr(
+        {
+            "Technique": ["T1078.004"],
+            "Tactics": ["TA0001", "TA0004"],
+            "Mitigations": ["M1026"],
+        }
+    )
+    return f"""
+    <!DOCTYPE html>
+    <html>
+    <body>
+      <wb-recommendation-data attribute="description"
+        text="Audit /usr/bin/containerd-shim if applicable."></wb-recommendation-data>
+      <wb-recommendation-data attribute="rationale_statement"
+        text="Auditing the containerd shim is important."></wb-recommendation-data>
+      <wb-recommendation-data attribute="impact_statement"
+        text="Audit logs will grow quickly."></wb-recommendation-data>
+      <wb-recommendation-data attribute="audit_procedure"
+        text="Run auditctl -l and grep for the binary."></wb-recommendation-data>
+      <wb-recommendation-data attribute="remediation_procedure"
+        text="Add an audit rule for /usr/bin/containerd-shim."></wb-recommendation-data>
+      <wb-recommendation-data attribute="default_value"
+        text="Not audited by default."></wb-recommendation-data>
+      <wb-recommendation-data attribute="artifact_equation"
+        text="OR(1,2)"></wb-recommendation-data>
+      <wb-recommendation-data attribute="references"
+        text="NIST SP 800-53 Rev. 5: AU-2, SI-3"></wb-recommendation-data>
+      <wb-recommendation-data attribute="notes"
+        text="Applies only to Docker hosts."></wb-recommendation-data>
+      <wb-recommendation-data attribute="automated_scoring"
+        text="Automated"></wb-recommendation-data>
+      <wb-recommendation-data attribute="profiles"
+        text="Level 2 - Docker - Linux"></wb-recommendation-data>
+
+      <wb-recommendation-feature-controls
+        title="CIS Controls"
+        :controls="{controls_payload}">
+      </wb-recommendation-feature-controls>
+
+      <wb-recommendation-mitre-mappings
+        :mappings="{mitre_payload}">
+      </wb-recommendation-mitre-mappings>
+
+      <wb-recommendation-artifacts
+        artifacts-json='[{{"id": 1, "view_level": "1.1.1", "title": "Artifact",
+        "status": "published", "artifact_type": {{"id": 1, "name": "Command"}}}}]'>
+      </wb-recommendation-artifacts>
+    </body>
+    </html>
+    """
+
+
+@pytest.fixture
+def v2_minimal_html():
+    """Minimal V2 HTML — only the signature element is present."""
+    return """
+    <wb-recommendation-data attribute="description" text="Just a description."></wb-recommendation-data>
+    """
+
+
+@pytest.fixture
+def v2_controls_as_list_html():
+    """V2 HTML where :controls is serialized as a list (not a dict)."""
+    payload = _vue_json_attr(
+        [
+            {
+                "title": "Only Control",
+                "control": "1.1",
+                "version": 8,
+                "ig1": True,
+                "ig2": True,
+                "ig3": True,
+            }
+        ]
+    )
+    return f"""
+    <wb-recommendation-data attribute="description" text="x"></wb-recommendation-data>
+    <wb-recommendation-feature-controls :controls="{payload}">
+    </wb-recommendation-feature-controls>
+    """
+
+
+@pytest.fixture
+def clear_detector():
+    """Ensure each test starts with a clean detector registry."""
+    original = list(StrategyDetector._strategies)
+    StrategyDetector.clear_strategies()
+    yield
+    StrategyDetector.clear_strategies()
+    for strategy in reversed(original):
+        StrategyDetector.register_strategy(strategy, position=0)
+
+
+# ============ Compatibility Detection ============
+
+
+class TestV2IsCompatible:
+    def test_matches_v2_signature(self, v2_minimal_html):
+        assert WorkbenchV2Strategy().is_compatible(v2_minimal_html) is True
+
+    def test_rejects_v1_html(self):
+        html = '<div id="description-recommendation-data">x</div>'
+        assert WorkbenchV2Strategy().is_compatible(html) is False
+
+    def test_rejects_empty_html(self):
+        assert WorkbenchV2Strategy().is_compatible("") is False
+
+    def test_matches_on_audit_only(self):
+        html = (
+            '<wb-recommendation-data attribute="audit_procedure" text="x"></wb-recommendation-data>'
+        )
+        assert WorkbenchV2Strategy().is_compatible(html) is True
+
+
+# ============ Vue Payload Decoding ============
+
+
+class TestDecodeVuePayload:
+    def test_unwraps_json_parse_and_decodes_escapes(self):
+        raw = r"""JSON.parse('[{\u0022a\u0022:1}]')"""
+        assert _decode_vue_payload(raw) == '[{"a":1}]'
+
+    def test_returns_input_when_no_wrapper(self):
+        assert _decode_vue_payload('{"a":1}') == '{"a":1}'
+
+    def test_none_passthrough(self):
+        assert _decode_vue_payload(None) is None
+
+    def test_empty_string(self):
+        assert _decode_vue_payload("") is None
+
+
+# ============ Field Extraction ============
+
+
+class TestV2ExtractRecommendation:
+    def test_extracts_all_text_fields(self, v2_full_html):
+        data = WorkbenchV2Strategy().extract_recommendation(v2_full_html)
+
+        assert data["description"] == "Audit /usr/bin/containerd-shim if applicable."
+        assert data["rationale"] == "Auditing the containerd shim is important."
+        assert data["impact"] == "Audit logs will grow quickly."
+        assert data["audit"] == "Run auditctl -l and grep for the binary."
+        assert data["remediation"] == "Add an audit rule for /usr/bin/containerd-shim."
+        assert data["default_value"] == "Not audited by default."
+        assert data["artifact_equation"] == "OR(1,2)"
+        assert data["references"] == "NIST SP 800-53 Rev. 5: AU-2, SI-3"
+        assert data["additional_info"] == "Applies only to Docker hosts."
+
+    def test_extracts_assessment_status(self, v2_full_html):
+        data = WorkbenchV2Strategy().extract_recommendation(v2_full_html)
+        assert data["assessment_status"] == "Automated"
+
+    def test_extracts_profiles_as_list(self, v2_full_html):
+        data = WorkbenchV2Strategy().extract_recommendation(v2_full_html)
+        assert data["profiles"] == ["Level 2 - Docker - Linux"]
+
+    def test_parses_nist_from_references(self, v2_full_html):
+        data = WorkbenchV2Strategy().extract_recommendation(v2_full_html)
+        assert "AU-2" in data["nist_controls"]
+        assert "SI-3" in data["nist_controls"]
+
+    def test_missing_fields_yield_none(self, v2_minimal_html):
+        data = WorkbenchV2Strategy().extract_recommendation(v2_minimal_html)
+        assert data["description"] == "Just a description."
+        assert data["audit"] is None
+        assert data["remediation"] is None
+        assert data["assessment_status"] == "Unknown"
+        assert data["profiles"] == []
+
+
+# ============ CIS Controls Normalization ============
+
+
+class TestV2ExtractCisControls:
+    def test_dict_payload_becomes_list(self, v2_full_html):
+        data = WorkbenchV2Strategy().extract_recommendation(v2_full_html)
+        assert len(data["cis_controls"]) == 2
+        assert all(isinstance(c, CISControl) for c in data["cis_controls"])
+
+    def test_list_payload_works(self, v2_controls_as_list_html):
+        data = WorkbenchV2Strategy().extract_recommendation(v2_controls_as_list_html)
+        assert len(data["cis_controls"]) == 1
+        assert data["cis_controls"][0].control == "1.1"
+        assert data["cis_controls"][0].ig1 is True
+
+    def test_null_ig_coerced_to_false(self, v2_full_html):
+        data = WorkbenchV2Strategy().extract_recommendation(v2_full_html)
+        # Second control has ig1=null in the fixture.
+        second = next(c for c in data["cis_controls"] if c.control == "6.8")
+        assert second.ig1 is False
+        assert second.ig2 is True
+        assert second.ig3 is True
+
+    def test_missing_feature_controls_element(self, v2_minimal_html):
+        data = WorkbenchV2Strategy().extract_recommendation(v2_minimal_html)
+        assert data["cis_controls"] == []
+
+
+# ============ MITRE Mapping ============
+
+
+class TestV2ExtractMitre:
+    def test_parses_mitre_keys(self, v2_full_html):
+        data = WorkbenchV2Strategy().extract_recommendation(v2_full_html)
+        assert isinstance(data["mitre_mapping"], MITREMapping)
+        assert data["mitre_mapping"].techniques == ["T1078.004"]
+        assert data["mitre_mapping"].tactics == ["TA0001", "TA0004"]
+        assert data["mitre_mapping"].mitigations == ["M1026"]
+
+    def test_missing_mitre_element(self, v2_minimal_html):
+        data = WorkbenchV2Strategy().extract_recommendation(v2_minimal_html)
+        assert data["mitre_mapping"] is None
+
+    def test_empty_mitre_returns_none(self):
+        empty = _vue_json_attr({"Technique": [], "Tactics": [], "Mitigations": []})
+        html = f"""
+        <wb-recommendation-data attribute="description" text="x"></wb-recommendation-data>
+        <wb-recommendation-mitre-mappings :mappings="{empty}">
+        </wb-recommendation-mitre-mappings>
+        """
+        data = WorkbenchV2Strategy().extract_recommendation(html)
+        assert data["mitre_mapping"] is None
+
+
+# ============ End-to-End Model Validation ============
+
+
+class TestV2RecommendationModelValidation:
+    """The full dict from V2 must satisfy the Pydantic Recommendation model."""
+
+    def test_builds_valid_recommendation(self, v2_full_html):
+        data = WorkbenchV2Strategy().extract_recommendation(v2_full_html)
+        rec = Recommendation(
+            ref="1.1.15",
+            title="Ensure auditing is configured for containerd-shim",
+            url="https://workbench.cisecurity.org/sections/1/recommendations/2",
+            **data,
+        )
+        assert rec.assessment_status == "Automated"
+        assert len(rec.cis_controls) == 2
+        assert rec.mitre_mapping is not None
+
+
+# ============ Detector Integration ============
+
+
+class TestV2DetectorIntegration:
+    def test_detector_picks_v2_for_vue_html(self, clear_detector, v2_minimal_html):
+        StrategyDetector.register_strategy(WorkbenchV1Strategy(), position=0)
+        StrategyDetector.register_strategy(WorkbenchV2Strategy(), position=0)
+
+        strategy = StrategyDetector.detect_strategy(v2_minimal_html)
+        assert strategy.version == "v2_2026_01"
+
+    def test_detector_still_picks_v1_for_legacy_html(self, clear_detector):
+        StrategyDetector.register_strategy(WorkbenchV1Strategy(), position=0)
+        StrategyDetector.register_strategy(WorkbenchV2Strategy(), position=0)
+
+        legacy = """
+        <div id="description-recommendation-data"><p>x</p></div>
+        <div id="rationale_statement-recommendation-data"><p>y</p></div>
+        <div id="audit_procedure-recommendation-data"><p>z</p></div>
+        """
+        strategy = StrategyDetector.detect_strategy(legacy)
+        assert strategy.version == "v1_2025_10"


### PR DESCRIPTION
## Summary

Fixes #9. Restores benchmark downloads after the CIS WorkBench Vue.js SPA migration (early 2026) that broke `WorkbenchV1Strategy`.

Content moved out of server-rendered `<div id="*-recommendation-data">` blocks and into attributes on Vue web components, so `v1_current.is_compatible()` never matched and the detector raised `"No compatible scraper strategy found"` for every recommendation. Downloads completed with `recommendations: []` stubs and `scraper_version: manual`.

## Changes

- **`src/cis_bench/fetcher/strategies/v2_2026.py`** (new) — `WorkbenchV2Strategy`, version `v2_2026_01`. Handles the new Vue format:
  - `<wb-recommendation-data attribute="X" text="...">` for all text fields (description, rationale, impact, audit, remediation, default_value, artifact_equation, references, notes, automated_scoring, profiles).
  - `<wb-recommendation-feature-controls :controls="JSON.parse('...')">` for CIS Controls, normalizing two upstream quirks:
    - `\uXXXX` escapes must be decoded before `json.loads` (Python doesn't decode them outside JSON string contexts; JavaScript's `JSON.parse` does).
    - Payload may be a list **or** a dict keyed by index (`{"0": {...}, "1": {...}}`); `ig1/ig2/ig3` may be `null` — coerced to `False` so the Pydantic `CISControl` model validates.
  - `<wb-recommendation-mitre-mappings :mappings="JSON.parse('...')">` for MITRE ATT&CK (new element; replaces the old HTML table). Accepts capitalized `Technique`/`Tactics`/`Mitigations` and lowercase plural variants.
  - `<wb-recommendation-artifacts>` — prefers the still-served legacy `artifacts-json` attribute, falls back to Vue-wrapped `:artifacts`.
- **`src/cis_bench/fetcher/strategies/__init__.py`** — registers `WorkbenchV2Strategy` at position 0 so the detector prefers it; `WorkbenchV1Strategy` stays registered as a fallback for any cached/legacy HTML.
- **`tests/integration/test_strategies_v2.py`** (new) — 23 tests covering compatibility detection, Vue payload decoding, dict-vs-list controls normalization, null-IG coercion, MITRE parsing, full `Recommendation` Pydantic model validation, and v1/v2 detector coexistence.

The output dict shape from `extract_recommendation()` is identical to v1's, so `workbench.py` and the `Recommendation` model are untouched.

## Why a new strategy instead of patching v1

Follows the pattern documented in `docs/developer-guide/architecture.md:317-320` ("Adding new HTML format: 1) Create new strategy class, 2) Register with detector, 3) Old benchmarks still work"). Version naming `v2_2026_01` matches the `v{major}_{YYYY}_{MM}` convention from `base.py`. Keeping v1 registered preserves backwards compatibility for any cached pre-2026 HTML.

## Test plan

- [x] `pytest tests/integration/test_strategies_v2.py -v` — 23/23 pass
- [x] `pytest tests/` — 1144/1144 pass, zero regressions
- [x] `ruff check` + `ruff format --check` — clean
- [x] `bandit -c pyproject.toml -r src/cis_bench/fetcher/strategies/v2_2026.py` — zero issues
- [x] Live download `cis-bench download 11818` (CIS Docker Benchmark v1.6.0):
  - Before: every rec logged `"No compatible scraper strategy found"`, output was empty stubs.
  - After: **117/117 recommendations**, **240 CIS Controls**, `scraper_version: v2_2026_01`. Recommendation 2657566 (the one from the original report) extracts title, description, profiles, assessment status, and controls cleanly.
- [ ] Reviewer: please run a download against a benchmark with MITRE mappings (e.g. AWS Foundations v6.0.0, id 21960) to confirm bug 4 fix end-to-end.

## Related

- Issue #9 — original bug report with four-bug breakdown by @egallis31.
