### PR TITLE
fix: ship cis-cci-mapping.json in the wheel (0.5.1 packaging regression)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,9 +94,15 @@ cis-bench = "cis_bench.cli.app:cli"
 packages = {find = {where = ["src"]}}
 
 [tool.setuptools.package-data]
-# Include YAML config files in package distribution
-# Fix for Issue #6: --style flag error due to missing configs
-cis_bench = ["exporters/configs/**/*.yaml"]
+# Include data files that are loaded at runtime via Path(__file__).parent.
+# Issue #6: XCCDF style YAML configs must ship with the wheel.
+# 0.5.1 bug: cis-cci-mapping.json is loaded by utils/cci_lookup.py on every
+# XCCDF export and must be shipped too, otherwise exports fail with
+# FileNotFoundError on fresh installs.
+cis_bench = [
+    "exporters/configs/**/*.yaml",
+    "data/*.json",
+]
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]


### PR DESCRIPTION
## Summary

0.5.1 ships a broken wheel: `cis-cci-mapping.json` is loaded at runtime by `utils/cci_lookup.py` but is not listed in `[tool.setuptools.package-data]`. Setuptools drops it from the wheel, so every `cis-bench export --format xccdf` crashes on fresh installs with:

```
FileNotFoundError: [Errno 2] No such file or directory:
'.../site-packages/cis_bench/data/cis-cci-mapping.json'
```

Fix is one line: add `"data/*.json"` to the package-data glob so the file ships alongside the existing YAML style configs.

## Why this wasn't caught before release

- **Editable installs mask the bug.** `pip install -e .` and `uv sync` both resolve package resources directly from the source tree (`src/cis_bench/data/cis-cci-mapping.json`), so the file is always reachable during development regardless of `package-data`. The bug only appears when setuptools actually builds a wheel — i.e. during release CI or a clean `uv build`.
- **The CCI code path runs late.** `cci_lookup.py` only loads during XCCDF export (`MappingEngine.__init__` → `get_cci_service()`). The smoke test for the v2 scraper fix (#9) only exercised `cis-bench download`, which never touches the CCI service, so nothing flagged the packaging regression before 0.5.1 tagged.
- **Stale `src/cis_bench.egg-info` lies.** An `egg-info` left behind by a previous editable install caches a `SOURCES.txt` that can make a local `python -m build` appear to include the JSON even when `package-data` doesn't list it. The release CI builds cleanly and therefore produces the bad wheel while local rebuilds silently stay green.

## Changes

- **`pyproject.toml`** — add `"data/*.json"` to the `cis_bench` package-data list, and update the comment to document both the existing YAML inclusion (#6) and this JSON inclusion.

No source code changes. The JSON file was already on disk at `src/cis_bench/data/cis-cci-mapping.json` — only the packaging manifest needed to claim it.

## Test plan

- [x] Reproduced the bug on `upstream/main`: `rm -rf dist build src/cis_bench.egg-info && uv build --wheel` produces a wheel whose RECORD contains no `data/` entries. Matches published PyPI 0.5.1 wheel byte-for-byte in that respect.
- [x] Applied the fix, repeated the clean rebuild, and confirmed the wheel now contains `cis_bench/data/cis-cci-mapping.json`:
      ```
      cis_bench/data/cis-cci-mapping.json
      cis_bench/exporters/configs/base.yaml
      cis_bench/exporters/configs/styles/cis.yaml
      cis_bench/exporters/configs/styles/disa.yaml
      ```
- [x] Installed the fixed wheel into a throwaway `uv venv` (not the dev editable install) and ran `cis-bench export 11818 --format xccdf --style disa` — 117 recommendations exported to a 326 KB XCCDF DISA XML file, CCI lookup active, no FileNotFoundError.
- [ ] Reviewer: please verify against a second benchmark and also `--style cis` to confirm both export styles work.

## Reproduction / verification workflow (for future packaging regressions)

```bash
# Always start clean — stale egg-info lies about wheel contents
rm -rf dist build src/cis_bench.egg-info

# Build
uv build --wheel

# Inspect BEFORE installing — catches missing data files immediately
python -c "import zipfile; [print(n) for n in zipfile.ZipFile('dist/cis_bench-*.whl').namelist() if n.endswith(('.json','.yaml','.sql'))]"

# Install into a throwaway uv venv — NOT the dev environment
rm -rf /tmp/uv-smoke
uv venv /tmp/uv-smoke --python 3.12
uv pip install --python /tmp/uv-smoke/bin/python dist/cis_bench-*.whl

# Exercise every CLI subcommand that touches packaged resources
/tmp/uv-smoke/bin/cis-bench auth login --browser firefox
/tmp/uv-smoke/bin/cis-bench download <id>
/tmp/uv-smoke/bin/cis-bench export <id> --format xccdf --style disa
/tmp/uv-smoke/bin/cis-bench export <id> --format xccdf --style cis
```

## Related

- Introduced by the addition of `utils/cci_lookup.py` and its JSON data file without a corresponding `package-data` entry.
- Surfaced publicly once the v2 scraper fix (#9 / PR #10) let exports reach the CCI stage on real benchmarks.
