### PR TITLE
fix(fts): handle invalid characters in FTS5 query

### DIFF
--- a/src/cis_bench/catalog/database.py
+++ b/src/cis_bench/catalog/database.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from sqlalchemy import text
 from sqlmodel import Session, SQLModel, create_engine, select
 
+from cis_bench.catalog.fts import build_fts_query
 from cis_bench.catalog.models import (
     BenchmarkCollection,
     BenchmarkStatusModel,
@@ -343,12 +344,7 @@ class CatalogDatabase:
                 return self._list_all(platform, platform_type, status, latest_only, limit, session)
 
             # FTS5 query formatting
-            # Note: FTS5 doesn't support leading wildcards (*word)
-            # Only trailing wildcards work (word*)
-            if not query.endswith("*"):
-                fts_query = f"{query}*"
-            else:
-                fts_query = query
+            fts_query = build_fts_query(query)
 
             # Use raw SQL for FTS5 + joins
             sql = """

--- a/src/cis_bench/catalog/fts.py
+++ b/src/cis_bench/catalog/fts.py
@@ -1,0 +1,27 @@
+import re
+
+
+def build_fts_query(query: str) -> str:
+    """
+    Convert a user query into a safe FTS5 query.
+
+    - Removes characters that break FTS5 syntax (e.g. '.', ':', etc.)
+    - Splits into tokens
+    - Applies prefix matching (*) to each term
+
+    Note:
+        This may slightly change semantics for inputs like "20.04",
+        which becomes "20* 04*".
+    """
+    if not query or not query.strip():
+        return ""
+
+    # Replace only problematic FTS characters
+    # Keep alphanumerics, replace others with space
+    cleaned = re.sub(r"[^\w\s]", " ", query, flags=re.UNICODE)
+
+    terms = cleaned.split()
+
+    # Note: FTS5 doesn't support leading wildcards (*word)
+    # Only trailing wildcards work (word*)
+    return " ".join(f"{t}*" for t in terms)

--- a/tests/unit/test_fts_query.py
+++ b/tests/unit/test_fts_query.py
@@ -1,0 +1,17 @@
+from cis_bench.catalog.fts import build_fts_query
+
+
+def test_fts_query_basic():
+    assert build_fts_query("ubuntu") == "ubuntu*"
+
+
+def test_fts_query_version():
+    assert build_fts_query("ubuntu 20.04") == "ubuntu* 20* 04*"
+
+
+def test_fts_query_symbols():
+    assert build_fts_query("test!!!") == "test*"
+
+
+def test_fts_query_empty():
+    assert build_fts_query("") == ""


### PR DESCRIPTION
## Problem
Queries like "ubuntu 20.04" cause:
sqlite3.OperationalError: fts5: syntax error near "."

## Cause
FTS5 does not accept certain special characters like '.' in MATCH queries.

## Solution
Sanitize input query before passing to FTS:
- Remove invalid characters
- Tokenize safely
- Add prefix matching

## Result
"ubuntu 20.04" → "ubuntu* 20* 04*"
No more crashes.